### PR TITLE
fix: images now fit all the content

### DIFF
--- a/styles/h5p-image-sequencing.css
+++ b/styles/h5p-image-sequencing.css
@@ -212,9 +212,8 @@ border-bottom: 1px solid #dde4ea;
 }
 
 .draggabled .image-container img {
-    height: auto;
-    max-height: 100%;
-    max-width: 100%;
+    height: 100%;
+    width: 100%;
     /* Vertical align it */
     position: relative;
     top: 50%;


### PR DESCRIPTION
## [Bug] Fix in Images

#### Bug description
The images don't fit all the content so there is a grey line in the back. This is caused by the inset box shadow.

#### Expected result
The expected result with this changes should be like this.
![image](https://user-images.githubusercontent.com/49620780/154942875-21f8d6f3-2ea5-44d2-a33f-a46fa2b7cbba.png)


#### Actual result
You should appreciate it here.
![image](https://user-images.githubusercontent.com/49620780/154942993-0facf00c-c268-4193-8f7d-3b6f348555e1.png)


#### Steps to reproduce
1. Create a new Image Sequencing activity.
2. Insert any image.
3. See the bug

#### Context
How has this issue affected you? What are you trying to accomplish?
_We are using H5P in prod and need native support of this._
