### PR TITLE
Fix page scroll when object is loaded

### DIFF
--- a/scripts/h5p-image-sequencing.js
+++ b/scripts/h5p-image-sequencing.js
@@ -568,7 +568,6 @@ H5P.ImageSequencing = (function (EventDispatcher, $, UI) {
         that.$list.appendTo($container);
         that.$footerContainer.appendTo($container);
 
-        that.sequencingCards[0].setFocus();
         that.activateSortableFunctionality();
         that.trigger('resize');
       }


### PR DESCRIPTION
It fixes page scroll when object is loaded and is placed on the bottom of the page. 

This fixes problem described in this issue https://github.com/jithin-space/h5p-ImageSequencing/issues/9